### PR TITLE
Use node:7.2-alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM alpine:3.4
+FROM node:7.2-alpine
 
-RUN apk add --update --no-cache make gcc g++ python nodejs git && \
-  rm -rf /tmp/* /var/cache/apk/*
+RUN apk add --no-cache git
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -1,26 +1,24 @@
 # alpine-node
-Minimal Node/io.js Docker Images built on Alpine Linux
-Size: 76 MB (All Layers: 236.8 MB)
+
+Minimal Node/io.js Docker Images built on Alpine Linux version.
+Size: 72.88 MB
 
 Layers:
-- alpine:3.4 5 MB
-- g++ 147 MB (needed for node-sass)
-- git 17 MB (needed to checkout some repo outside npm)
-- nodejs 27 MB
-- python 38 MB (needed for node-sass)
+- node:7.2-alpine 55.3 MB
+- git 17.58 MB (needed to checkout some repo outside npm)
 
 # Node version
 
 ```
 docker run --rm zenika/alpine-node node -v
-v6.2.0
+v7.2.0
 ```
 
 # NPM version
 
 ```
 docker run --rm zenika/alpine-node npm -v
-3.8.9
+3.10.9
 ```
 
 # GIT version
@@ -28,11 +26,4 @@ docker run --rm zenika/alpine-node npm -v
 ```
 docker run --rm zenika/alpine-node git --version
 git version 2.8.3
-```
-
-# Python version
-
-```
-docker run --rm zenika/alpine-node python -V
-Python 2.7.12
 ```


### PR DESCRIPTION
Par contre, pour ce qui est de `node-sass` j'y connais rien, mais au pire on peut faire un truc de ce genre (build testé mais pas la pertinence du résultat) :

```diff
diff --git i/Dockerfile w/Dockerfile
index 89a1826..8f67208 100644
--- i/Dockerfile
+++ w/Dockerfile
@@ -1,5 +1,12 @@
 FROM node:7.2-alpine
 
 RUN apk add --no-cache git
+RUN apk add --no-cache --virtual .build-deps \
+        g++ \
+        make \
+        python \
+    && npm --quiet install --global node-sass \
+    && apk del .build-deps \
+    && rm -rf /tmp/*
 
 WORKDIR /usr/src/app
```

Ça ajoute une couche de 42.98 MB.